### PR TITLE
Fix wrong version in GUI title and set default value of adapt resources to "META-INF/MANIFEST.MF"

### DIFF
--- a/Radon-GUI/src/main/java/me/itzsomebody/radon/gui/tabs/ObfuscationTab.java
+++ b/Radon-GUI/src/main/java/me/itzsomebody/radon/gui/tabs/ObfuscationTab.java
@@ -203,7 +203,7 @@ public class ObfuscationTab extends JPanel {
         renamingAdaptResources.setEnabled(false);
         renamingPanel.add(renamingAdaptResources, gbc_renamingAdaptResources);
 
-        renamingResourcesField = new JTextField();
+        renamingResourcesField = new JTextField("META-INF/MANIFEST.MF");
         GridBagConstraints gbc_renamingResourcesField = new GridBagConstraints();
         gbc_renamingResourcesField.gridwidth = 2;
         gbc_renamingResourcesField.insets = new Insets(0, 0, 5, 5);

--- a/Radon-Program/src/main/java/me/itzsomebody/radon/Main.java
+++ b/Radon-Program/src/main/java/me/itzsomebody/radon/Main.java
@@ -27,7 +27,7 @@ public class Main {
      * Static abuse variables xD
      */
     public static final String PREFIX = "[Radon]";
-    public static final String VERSION = "1.0.1";
+    public static final String VERSION = "1.0.3";
     public static final String CONTRIBUTORS = "ItzSomebody, x0ark, Col-E, Artel and kazigk";
     public static final String PROPAGANDA_GARBAGE = String.format("Radon is a free and open-source java obfuscator with contributions from %s.\nVersion: %s\nWebsite: https://github.com/ItzSomebody/Radon", Main.CONTRIBUTORS, Main.VERSION);
 


### PR DESCRIPTION
You only changed the version in the pom file but left it at 1.0.1 in Radons code, which caused the GUI to display the wrong version.

(I never made a pull request on GitHub before, I hope I did this correctly xD)

EDIT: Ok I screwed up, I didn't want the second commit to be added here
EDIT 2: Internet tells me I need to create seperate branches, and since I'm too lazy to learn how this works and both commits are just a few characters anyways I'll just leave it like that