### PR TITLE
Added fake directories

### DIFF
--- a/src/main/java/me/itzsomebody/radon/Radon.java
+++ b/src/main/java/me/itzsomebody/radon/Radon.java
@@ -145,7 +145,12 @@ public class Radon {
 
             classes.values().forEach(classWrapper -> {
                 try {
-                    ZipEntry entry = new ZipEntry(classWrapper.getEntryName());
+
+                    String name = classWrapper.getEntryName();
+                    if(config.isFakeDirectories())
+                        name += "/";
+
+                    ZipEntry entry = new ZipEntry(name);
 
                     zos.putNextEntry(entry);
                     zos.write(classWrapper.toByteArray(this));

--- a/src/main/java/me/itzsomebody/radon/config/ConfigurationSetting.java
+++ b/src/main/java/me/itzsomebody/radon/config/ConfigurationSetting.java
@@ -60,6 +60,7 @@ public enum ConfigurationSetting {
     VERIFY(Boolean.class, null),
     CORRUPT_CRC(Boolean.class, null),
     TRASH_CLASSES(Integer.class, null),
+    FAKE_DIRECTORY(Boolean.class, null),
 
     // ============ transformers
     STRING_ENCRYPTION(Map.class, new StringEncryption()),

--- a/src/main/java/me/itzsomebody/radon/config/ObfuscationConfiguration.java
+++ b/src/main/java/me/itzsomebody/radon/config/ObfuscationConfiguration.java
@@ -35,6 +35,7 @@ import me.itzsomebody.radon.utils.FileUtils;
 
 import static me.itzsomebody.radon.config.ConfigurationSetting.COMPRESSION_LEVEL;
 import static me.itzsomebody.radon.config.ConfigurationSetting.CORRUPT_CRC;
+import static me.itzsomebody.radon.config.ConfigurationSetting.FAKE_DIRECTORY;
 import static me.itzsomebody.radon.config.ConfigurationSetting.DICTIONARY;
 import static me.itzsomebody.radon.config.ConfigurationSetting.EXCLUSIONS;
 import static me.itzsomebody.radon.config.ConfigurationSetting.INPUT;
@@ -102,6 +103,7 @@ public final class ObfuscationConfiguration {
         obfConfig.setCompressionLevel(config.getOrDefault(COMPRESSION_LEVEL, Deflater.BEST_COMPRESSION));
         obfConfig.setVerify(config.getOrDefault(VERIFY, false));
         obfConfig.setCorruptCrc(config.getOrDefault(CORRUPT_CRC, false));
+        obfConfig.setFakeDirectories(config.getOrDefault(FAKE_DIRECTORY, false));
         obfConfig.setnTrashClasses(config.getOrDefault(TRASH_CLASSES, 0));
 
         // TRANSFORMERS
@@ -135,6 +137,7 @@ public final class ObfuscationConfiguration {
     private int compressionLevel;
     private boolean verify;
     private boolean corruptCrc;
+    private boolean fakeDirectories;
     private int nTrashClasses;
 
     private List<Transformer> transformers;
@@ -209,6 +212,14 @@ public final class ObfuscationConfiguration {
 
     public void setCorruptCrc(boolean corruptCrc) {
         this.corruptCrc = corruptCrc;
+    }
+
+    public boolean isFakeDirectories() {
+        return fakeDirectories;
+    }
+
+    public void setFakeDirectories(boolean fakeDirectories) {
+        this.fakeDirectories = fakeDirectories;
     }
 
     public int getnTrashClasses() {


### PR DESCRIPTION
Completely breaks Luyten, JByteMod. Those are just the ones I've tested. They dont show any classes whatsoever, only the package names.

Also zip file explorers, like WinRAR wont allow you to copy/edit or even extract the class files.

Credit to @Cubxity and @half-cambodian-hacker-man . This is I think partially how paramorphism's corruption flag works.

How to use:
```Yaml
fake_directory: true
```
in config.