### PR TITLE
Fix hierarchy building

### DIFF
--- a/src/main/java/me/itzsomebody/radon/Radon.java
+++ b/src/main/java/me/itzsomebody/radon/Radon.java
@@ -298,7 +298,7 @@ public class Radon {
         if (hierarchy.get(wrapper.getName()) == null) {
             ClassTree tree = new ClassTree(wrapper);
 
-            if (wrapper.getSuperName() != null) {
+            if (wrapper.getSuperName() != null && !wrapper.getSuperName().equals("java/lang/Object")) {
                 tree.getParentClasses().add(wrapper.getSuperName());
 
                 buildHierarchy(getClassWrapper(wrapper.getSuperName()), wrapper);


### PR DESCRIPTION
ASM documentation says `ClassNode#superName` MAY be null for the superclass `java.lang.Object`.

In my experience it actually returned the said superclass' name,
resulting in an incorrect hierarchy map, breaking the renamer transformer.