### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,8 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
 }
 
-allprojects {
-    tasks.withType(Test).configureEach {
-        forkEvery = 100
-    }
 
+tasks.withType(Test).configureEach {
+    forkEvery = 100
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -42,3 +42,10 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
     testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
 }
+
+allprojects {
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
+}


### PR DESCRIPTION

[Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options). Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork a new test VM after a certain number of tests have run by setting `forkEvery`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
